### PR TITLE
 Fix order order of parameters

### DIFF
--- a/TARGET_STM/TARGET_STM32F4/sdio_device.c
+++ b/TARGET_STM/TARGET_STM32F4/sdio_device.c
@@ -118,7 +118,7 @@ void HAL_SD_MspInit(SD_HandleTypeDef *hsd)
         hdma_sdio_rx.Init.PeriphBurst = DMA_PBURST_INC4;
         if (HAL_DMA_Init(&hdma_sdio_rx) != HAL_OK)
         {
-            error("SDIO DMA Init error at %d in %s", __FILE__, __LINE__);
+            error("SDIO DMA Init error at %d in %s", __LINE__, __FILE__);
         }
 
         __HAL_LINKDMA(hsd, hdmarx, hdma_sdio_rx);
@@ -145,7 +145,7 @@ void HAL_SD_MspInit(SD_HandleTypeDef *hsd)
         hdma_sdio_tx.Init.PeriphBurst = DMA_PBURST_INC4;
         if (HAL_DMA_Init(&hdma_sdio_tx) != HAL_OK)
         {
-            error("SDIO DMA Init error at %d in %s", __FILE__, __LINE__);
+            error("SDIO DMA Init error at %d in %s", __LINE__, __FILE__);
         }
 
         __HAL_LINKDMA(hsd, hdmatx, hdma_sdio_tx);

--- a/TARGET_STM/TARGET_STM32F7/sdio_device.c
+++ b/TARGET_STM/TARGET_STM32F7/sdio_device.c
@@ -118,7 +118,7 @@ void HAL_SD_MspInit(SD_HandleTypeDef *hsd)
         hdma_sdmmc_rx.Init.PeriphBurst = DMA_PBURST_INC4;
         if (HAL_DMA_Init(&hdma_sdmmc_rx) != HAL_OK)
         {
-            error("SDMMC DMA Init error at %d in %s", __FILE__, __LINE__);
+            error("SDMMC DMA Init error at %d in %s", __LINE__, __FILE__);
         }
 
         __HAL_LINKDMA(hsd, hdmarx, hdma_sdmmc_rx);
@@ -145,7 +145,7 @@ void HAL_SD_MspInit(SD_HandleTypeDef *hsd)
         hdma_sdmmc_tx.Init.PeriphBurst = DMA_PBURST_INC4;
         if (HAL_DMA_Init(&hdma_sdmmc_tx) != HAL_OK)
         {
-            error("SDMMC DMA Init error at %d in %s", __FILE__, __LINE__);
+            error("SDMMC DMA Init error at %d in %s", __LINE__, __FILE__);
         }
 
         __HAL_LINKDMA(hsd, hdmatx, hdma_sdmmc_tx);


### PR DESCRIPTION
In those two error() calls the parameters where swapped.